### PR TITLE
Expose renderers for extension

### DIFF
--- a/src/files/index.js
+++ b/src/files/index.js
@@ -1,9 +1,12 @@
-import ListThumbnailFile from './list-thumbnail.js'
+import ListThumbnailFile, { RawListThumbnailFile } from './list-thumbnail.js'
 import SimpleListThumbnailFile from './simple-list-thumbnail.js'
-import TableFile from './table.js'
+import TableFile, { RawTableFile } from './table.js'
 
 export {
   ListThumbnailFile,
   SimpleListThumbnailFile,
   TableFile,
+
+  RawListThumbnailFile,
+  RawTableFile,
 }

--- a/src/files/list-thumbnail.js
+++ b/src/files/list-thumbnail.js
@@ -7,13 +7,7 @@ import { NativeTypes } from 'react-dnd-html5-backend'
 import BaseFile, { BaseFileConnectors } from './../base-file.js'
 import { fileSize } from './utils.js'
 
-@DragSource('file', BaseFileConnectors.dragSource, BaseFileConnectors.dragCollect)
-@DropTarget(
-  ['file', 'folder', NativeTypes.FILE],
-  BaseFileConnectors.targetSource,
-  BaseFileConnectors.targetCollect,
-)
-class ListThumbnailFile extends BaseFile {
+class RawListThumbnailFile extends BaseFile {
   static defaultProps = {
     showName: true,
     showSize: true,
@@ -133,4 +127,13 @@ class ListThumbnailFile extends BaseFile {
   }
 }
 
+@DragSource('file', BaseFileConnectors.dragSource, BaseFileConnectors.dragCollect)
+@DropTarget(
+  ['file', 'folder', NativeTypes.FILE],
+  BaseFileConnectors.targetSource,
+  BaseFileConnectors.targetCollect,
+)
+class ListThumbnailFile extends RawListThumbnailFile {}
+
 export default ListThumbnailFile
+export { RawListThumbnailFile }

--- a/src/files/table.js
+++ b/src/files/table.js
@@ -7,13 +7,7 @@ import { NativeTypes } from 'react-dnd-html5-backend'
 import BaseFile, { BaseFileConnectors } from './../base-file.js'
 import { fileSize } from './utils.js'
 
-@DragSource('file', BaseFileConnectors.dragSource, BaseFileConnectors.dragCollect)
-@DropTarget(
-  ['file', 'folder', NativeTypes.FILE],
-  BaseFileConnectors.targetSource,
-  BaseFileConnectors.targetCollect,
-)
-class TableFile extends BaseFile {
+class RawTableFile extends BaseFile {
   render() {
     let icon
     if (this.isImage()) {
@@ -108,4 +102,13 @@ class TableFile extends BaseFile {
   }
 }
 
+@DragSource('file', BaseFileConnectors.dragSource, BaseFileConnectors.dragCollect)
+@DropTarget(
+  ['file', 'folder', NativeTypes.FILE],
+  BaseFileConnectors.targetSource,
+  BaseFileConnectors.targetCollect,
+)
+class TableFile extends RawTableFile {}
+
 export default TableFile
+export { RawTableFile }

--- a/src/folders/index.js
+++ b/src/folders/index.js
@@ -1,7 +1,10 @@
-import ListThumbnailFolder from './list-thumbnail.js'
-import TableFolder from './table.js'
+import ListThumbnailFolder, { RawListThumbnailFolder } from './list-thumbnail.js'
+import TableFolder, { RawTableFolder } from './table.js'
 
 export {
   ListThumbnailFolder,
   TableFolder,
+
+  RawListThumbnailFolder,
+  RawTableFolder,
 }

--- a/src/folders/list-thumbnail.js
+++ b/src/folders/list-thumbnail.js
@@ -6,13 +6,7 @@ import { NativeTypes } from 'react-dnd-html5-backend'
 import BaseFolder, { BaseFolderConnectors } from './../base-folder.js'
 import { BaseFileConnectors } from './../base-file.js'
 
-@DragSource('folder', BaseFolderConnectors.dragSource, BaseFolderConnectors.dragCollect)
-@DropTarget(
-  ['file', 'folder', NativeTypes.FILE],
-  BaseFileConnectors.targetSource,
-  BaseFileConnectors.targetCollect,
-)
-class ListThumbnailFolder extends BaseFolder {
+class RawListThumbnailFolder extends BaseFolder {
   render() {
     const icon = (<i className={`fa fa-folder${this.props.isOpen ? '-open' : ''}-o`} aria-hidden="true" />)
 
@@ -126,4 +120,13 @@ class ListThumbnailFolder extends BaseFolder {
   }
 }
 
+@DragSource('folder', BaseFolderConnectors.dragSource, BaseFolderConnectors.dragCollect)
+@DropTarget(
+  ['file', 'folder', NativeTypes.FILE],
+  BaseFileConnectors.targetSource,
+  BaseFileConnectors.targetCollect,
+)
+class ListThumbnailFolder extends RawListThumbnailFolder {}
+
 export default ListThumbnailFolder
+export { RawListThumbnailFolder }

--- a/src/folders/table.js
+++ b/src/folders/table.js
@@ -6,13 +6,7 @@ import { NativeTypes } from 'react-dnd-html5-backend'
 import BaseFolder, { BaseFolderConnectors } from './../base-folder.js'
 import { BaseFileConnectors } from './../base-file.js'
 
-@DragSource('folder', BaseFolderConnectors.dragSource, BaseFolderConnectors.dragCollect)
-@DropTarget(
-  ['file', 'folder', NativeTypes.FILE],
-  BaseFileConnectors.targetSource,
-  BaseFileConnectors.targetCollect,
-)
-class TableFolder extends BaseFolder {
+class RawTableFolder extends BaseFolder {
   render() {
     let icon
     if (this.props.isOpen) {
@@ -97,5 +91,13 @@ class TableFolder extends BaseFolder {
     return this.connectDND(folder)
   }
 }
+
+@DragSource('folder', BaseFolderConnectors.dragSource, BaseFolderConnectors.dragCollect)
+@DropTarget(
+  ['file', 'folder', NativeTypes.FILE],
+  BaseFileConnectors.targetSource,
+  BaseFileConnectors.targetCollect,
+)
+class TableFolder extends RawTableFolder {}
 
 export default TableFolder

--- a/src/headers/table.js
+++ b/src/headers/table.js
@@ -7,12 +7,7 @@ import { NativeTypes } from 'react-dnd-html5-backend'
 
 import { BaseFileConnectors } from './../base-file.js'
 
-@DropTarget(
-  ['file', 'folder', NativeTypes.FILE],
-  BaseFileConnectors.targetSource,
-  BaseFileConnectors.targetCollect,
-)
-class TableHeader extends React.Component {
+class RawTableHeader extends React.Component {
   static propTypes = {
     select: PropTypes.func,
     fileKey: PropTypes.string,
@@ -58,4 +53,12 @@ class TableHeader extends React.Component {
   }
 }
 
+@DropTarget(
+  ['file', 'folder', NativeTypes.FILE],
+  BaseFileConnectors.targetSource,
+  BaseFileConnectors.targetCollect,
+)
+class TableHeader extends RawTableHeader {}
+
 export default TableHeader
+export { RawTableHeader }


### PR DESCRIPTION
This isn't hugely pretty, and components should be composed rather than extended, BUT, for convenience, this PR exposes the raw, undecorated versions of all of the renderers.
Those who choose to extend these raw renderers should then decorate their extended component with the dnd stuff (just import and copy the same decoration that's done in the respective file) if they want dnd to work.

Fixes #16