### PR TITLE
Add export for RawTableFolder

### DIFF
--- a/src/folders/table.js
+++ b/src/folders/table.js
@@ -101,3 +101,4 @@ class RawTableFolder extends BaseFolder {
 class TableFolder extends RawTableFolder {}
 
 export default TableFolder
+export { RawTableFolder }


### PR DESCRIPTION
Added RawRableFolder export statement to allow for custom component creation.  

Looks like it was forgotten in this commit: https://github.com/uptick/react-keyed-file-browser/pull/17/commits/3c7bbf1f6ee654a92f41043bca5ed69d3d711452#diff-6eadf05f2571b5f56472ad582b259eb5