### PR TITLE
Allow FontAwesome icons to be overridden

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ var mount = document.querySelectorAll('div.browser-mount');
 ReactDOM.render(
   <FileBrowser
     files=[]
-    icons={icons.FontAwesome(4)}
+    icons={Icons.FontAwesome(4)}
   />,
   mount[0]
 );

--- a/README.md
+++ b/README.md
@@ -34,6 +34,41 @@ ReactDOM.render(
 );
 ```
 
+Include icons from FontAwesome 4:
+
+```javascript
+import React from 'react'
+import ReactDOM from 'react-dom'
+
+import FileBrowser, {Icons} from 'react-keyed-file-browser'
+
+var mount = document.querySelectorAll('div.browser-mount');
+ReactDOM.render(
+  <FileBrowser
+    files=[]
+    icons={icons.FontAwesome(4)}
+  />,
+  mount[0]
+);
+```
+
+or your own icons by specifying as so:
+```javascript
+  <FileBrowser
+    files=[]
+    icons={{
+      File: <i className="file" aria-hidden="true" />,
+      Image: <i className="file-image" aria-hidden="true" />,
+      PDF: <i className="file-pdf" aria-hidden="true" />,
+      Rename: <i className="i-cursor" aria-hidden="true" />,
+      Folder: <i className="folder" aria-hidden="true" />,
+      FolderOpen: <i className="folder-open" aria-hidden="true" />,
+      Delete: <i className="trash" aria-hidden="true" />,
+      Loading: <i className="circle-notch spin" aria-hidden="true" />,
+    }}
+  />
+```
+
 Optionally, include the built css with an import:
 
 ```scss

--- a/demo-site/demos.sass
+++ b/demo-site/demos.sass
@@ -2,5 +2,5 @@
 
 @import 'node_modules/react-keyed-file-browser/src/browser'
 
-$fa-font-path: '/react-keyed-file-browser/dist'
+$fa-font-path: "https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/fonts" !default
 @import 'node_modules/font-awesome/scss/font-awesome'

--- a/demo-site/grouped-thumbnails.js
+++ b/demo-site/grouped-thumbnails.js
@@ -2,11 +2,12 @@ import React from 'react'
 import ReactDOM from 'react-dom'
 import Moment from 'moment'
 
-import FileBrowser, { FileRenderers, FolderRenderers, Groupers } from 'react-keyed-file-browser'
+import FileBrowser, { FileRenderers, FolderRenderers, Groupers, Icons } from 'react-keyed-file-browser'
 
 const mount = document.querySelectorAll('div.demo-mount-grouped-thumbnails')
 ReactDOM.render(
   <FileBrowser
+    icons={Icons.FontAwesome(4)}
     files={[
       {
         key: 'cat.png',

--- a/demo-site/nested-editable.js
+++ b/demo-site/nested-editable.js
@@ -2,7 +2,7 @@ import React from 'react'
 import ReactDOM from 'react-dom'
 import Moment from 'moment'
 
-import FileBrowser from 'react-keyed-file-browser'
+import FileBrowser, {Icons} from 'react-keyed-file-browser'
 
 class NestedEditableDemo extends React.Component {
   state = {
@@ -149,6 +149,7 @@ class NestedEditableDemo extends React.Component {
     return (
       <FileBrowser
         files={this.state.files}
+        icons={Icons.FontAwesome(4)}
 
         onCreateFolder={this.handleCreateFolder}
         onCreateFiles={this.handleCreateFiles}

--- a/src/base-file.js
+++ b/src/base-file.js
@@ -17,6 +17,7 @@ class BaseFile extends React.Component {
     action: PropTypes.string,
 
     browserProps: PropTypes.shape({
+      icons: PropTypes.func,
       select: PropTypes.func,
       beginAction: PropTypes.func,
       endAction: PropTypes.func,

--- a/src/base-file.js
+++ b/src/base-file.js
@@ -17,7 +17,7 @@ class BaseFile extends React.Component {
     action: PropTypes.string,
 
     browserProps: PropTypes.shape({
-      icons: PropTypes.func,
+      icons: PropTypes.object,
       select: PropTypes.func,
       beginAction: PropTypes.func,
       endAction: PropTypes.func,

--- a/src/browser.js
+++ b/src/browser.js
@@ -41,6 +41,17 @@ class RawFileBrowser extends React.Component {
     group: PropTypes.func.isRequired,
     sort: PropTypes.func.isRequired,
 
+    icons: PropTypes.shape({
+      Folder: PropTypes.element,
+      FolderOpen: PropTypes.element,
+      File: PropTypes.element,
+      PDF: PropTypes.element,
+      Image: PropTypes.element,
+      Delete: PropTypes.element,
+      Rename: PropTypes.element,
+      Loading: PropTypes.element,
+    }),
+
     nestChildren: PropTypes.bool.isRequired,
     renderStyle: PropTypes.oneOf([
       'list',
@@ -92,6 +103,8 @@ class RawFileBrowser extends React.Component {
     folderRendererProps: {},
     detailRenderer: DefaultDetail,
     detailRendererProps: {},
+
+    icons: {},
   }
 
   state = {
@@ -332,6 +345,7 @@ class RawFileBrowser extends React.Component {
       fileRendererProps: this.props.fileRendererProps,
       folderRenderer: this.props.folderRenderer,
       folderRendererProps: this.props.folderRendererProps,
+      icons: this.props.icons,
 
       // browser state
       openFolders: this.state.openFolders,
@@ -362,14 +376,19 @@ class RawFileBrowser extends React.Component {
     }
   }
   renderActionBar(selectedItem) {
+    const {
+      icons, canFilter, filterRendererProps,
+      filterRenderer: FilterRenderer, onCreateFolder,
+      onRenameFile, onRenameFolder, onDeleteFile, onDeleteFolder,
+    } = this.props
     const selectionIsFolder = (selectedItem && !selectedItem.size)
     let filter
-    if (this.props.canFilter) {
+    if (canFilter) {
       filter = (
-        <this.props.filterRenderer
+        <FilterRenderer
           value={this.state.nameFilter}
           updateFilter={this.updateFilter}
-          {...this.props.filterRendererProps}
+          {...filterRendererProps}
         />
       )
     }
@@ -396,14 +415,14 @@ class RawFileBrowser extends React.Component {
         actions = (
           // TODO: Enable plugging in custom spinner.
           <div className="item-actions">
-            <i className="icon loading fa fa-circle-o-notch fa-spin" /> {actionText}
+            {icons.Loading} {actionText}
           </div>
         )
       } else {
         actions = []
         if (
           selectionIsFolder &&
-          typeof this.props.onCreateFolder === 'function' &&
+          typeof onCreateFolder === 'function' &&
           !this.state.nameFilter
         ) {
           actions.push(
@@ -413,7 +432,7 @@ class RawFileBrowser extends React.Component {
                 href="#"
                 role="button"
               >
-                <i className="fa fa-folder-o" aria-hidden="true" />
+                {icons.Folder}
                 &nbsp;Add Subfolder
               </a>
             </li>
@@ -421,8 +440,8 @@ class RawFileBrowser extends React.Component {
         }
         if (
           selectedItem.keyDerived && (
-            (!selectionIsFolder && typeof this.props.onRenameFile === 'function') ||
-            (selectionIsFolder && typeof this.props.onRenameFolder === 'function')
+            (!selectionIsFolder && typeof onRenameFile === 'function') ||
+            (selectionIsFolder && typeof onRenameFolder === 'function')
           )
         ) {
           actions.push(
@@ -432,7 +451,7 @@ class RawFileBrowser extends React.Component {
                 href="#"
                 role="button"
               >
-                <i className="fa fa-i-cursor" aria-hidden="true" />
+                {icons.Rename}
                 &nbsp;Rename
               </a>
             </li>
@@ -440,8 +459,8 @@ class RawFileBrowser extends React.Component {
         }
         if (
           selectedItem.keyDerived && (
-            (!selectionIsFolder && typeof this.props.onDeleteFile === 'function') ||
-            (selectionIsFolder && typeof this.props.onDeleteFolder === 'function')
+            (!selectionIsFolder && typeof onDeleteFile === 'function') ||
+            (selectionIsFolder && typeof onDeleteFolder === 'function')
           )
         ) {
           actions.push(
@@ -451,7 +470,7 @@ class RawFileBrowser extends React.Component {
                 href="#"
                 role="button"
               >
-                <i className="fa fa-trash-o" aria-hidden="true" />
+                {icons.Delete}
                 &nbsp;Delete
               </a>
             </li>
@@ -467,7 +486,7 @@ class RawFileBrowser extends React.Component {
       // Nothing selected: We're in the 'root' folder. Only allowed action is adding a folder.
       actions = []
       if (
-        typeof this.props.onCreateFolder === 'function' &&
+        typeof onCreateFolder === 'function' &&
         !this.state.nameFilter
       ) {
         actions.push(
@@ -477,7 +496,7 @@ class RawFileBrowser extends React.Component {
               href="#"
               role="button"
             >
-              <i className="fa fa-folder-o" aria-hidden="true" />
+              {icons.Folder}
               &nbsp;Add Folder
             </a>
           </li>
@@ -498,6 +517,10 @@ class RawFileBrowser extends React.Component {
     )
   }
   renderFiles(files, depth) {
+    const {
+      fileRenderer: FileRenderer, fileRendererProps,
+      folderRenderer: FolderRenderer, folderRendererProps,
+    } = this.props
     const browserProps = this.getBrowserProps()
     let renderedFiles = []
     files.map((file) => {
@@ -508,21 +531,21 @@ class RawFileBrowser extends React.Component {
 
       if (file.size) {
         renderedFiles.push(
-          <this.props.fileRenderer
+          <FileRenderer
             {...file}
             {...thisItemProps}
             browserProps={browserProps}
-            {...this.props.fileRendererProps}
+            {...fileRendererProps}
           />
         )
       } else {
         if (!this.state.nameFilter) {
           renderedFiles.push(
-            <this.props.folderRenderer
+            <FolderRenderer
               {...file}
               {...thisItemProps}
               browserProps={browserProps}
-              {...this.props.folderRendererProps}
+              {...folderRendererProps}
             />
           )
         }

--- a/src/files/list-thumbnail.js
+++ b/src/files/list-thumbnail.js
@@ -16,30 +16,35 @@ class RawListThumbnailFile extends BaseFile {
   }
 
   render() {
+    const {
+      thumbnail_url: thumbnailUrl, action, url,
+      isDragging, isRenaming, isSelected, isSelectable, isOver, isDeleting,
+      showName, showSize, showModified, browserProps, connectDragPreview,
+    } = this.props
     let icon
-    if (this.props.thumbnail_url) {
+    if (thumbnailUrl) {
       icon = (
         <div className="image" style={{
-          backgroundImage: 'url(' + this.props.thumbnail_url + ')',
+          backgroundImage: 'url(' + thumbnailUrl + ')',
         }} />
       )
     } else if (this.isImage()) {
-      icon = (<i className="fa fa-file-image-o" aria-hidden="true" />)
+      icon = browserProps.icons.Image
     } else if (this.isPdf()) {
-      icon = (<i className="fa fa-file-pdf-o" aria-hidden="true" />)
+      icon = browserProps.icons.PDF
     } else {
-      icon = (<i className="fa fa-file-o" aria-hidden="true" />)
+      icon = browserProps.icons.File
     }
 
-    const inAction = (this.props.isDragging || this.props.action)
+    const inAction = (isDragging || action)
 
     let name
-    if (this.props.showName) {
-      if (!inAction && this.props.isDeleting) {
+    if (showName) {
+      if (!inAction && isDeleting) {
         name = (
           <form className="deleting" onSubmit={this.handleDeleteSubmit}>
             <a
-              href={this.props.url}
+              href={url}
               download="download"
               onClick={this.handleFileClick}
             >
@@ -52,7 +57,7 @@ class RawListThumbnailFile extends BaseFile {
             </div>
           </form>
         )
-      } else if (!inAction && this.props.isRenaming) {
+      } else if (!inAction && isRenaming) {
         name = (
           <form className="renaming" onSubmit={this.handleRenameSubmit}>
             <input
@@ -67,7 +72,7 @@ class RawListThumbnailFile extends BaseFile {
         )
       } else {
         name = (
-          <a href={this.props.url} download="download" onClick={this.handleFileClick}>
+          <a href={url} download="download" onClick={this.handleFileClick}>
             {this.getName()}
           </a>
         )
@@ -75,26 +80,26 @@ class RawListThumbnailFile extends BaseFile {
     }
 
     let size
-    if (this.props.showSize) {
-      if (!this.props.isRenaming && !this.props.isDeleting) {
+    if (showSize) {
+      if (!isRenaming && !isDeleting) {
         size = (
-          <span className="size"><small>{fileSize(this.props.size)}</small></span>
+          <span className="size"><small>{fileSize(size)}</small></span>
         )
       }
     }
     let modified
-    if (this.props.showModified) {
-      if (!this.props.isRenaming && !this.props.isDeleting) {
+    if (showModified) {
+      if (!isRenaming && !isDeleting) {
         modified = (
           <span className="modified">
-            Last modified: {Moment(this.props.modified).fromNow()}
+            Last modified: {Moment(modified).fromNow()}
           </span>
         )
       }
     }
 
     let rowProps = {}
-    if (this.props.isSelectable) {
+    if (isSelectable) {
       rowProps = {
         onClick: this.handleItemClick,
       }
@@ -103,10 +108,10 @@ class RawListThumbnailFile extends BaseFile {
     let row = (
       <li
         className={ClassNames('file', {
-          pending: (this.props.action),
-          dragging: (this.props.isDragging),
-          dragover: (this.props.isOver),
-          selected: (this.props.isSelected),
+          pending: action,
+          dragging: isDragging,
+          dragover: isOver,
+          selected: isSelected,
         })}
         onDoubleClick={this.handleItemDoubleClick}
         {...rowProps}
@@ -119,8 +124,8 @@ class RawListThumbnailFile extends BaseFile {
         </div>
       </li>
     )
-    if (typeof this.props.browserProps.moveFile === 'function') {
-      row = this.props.connectDragPreview(row)
+    if (typeof browserProps.moveFile === 'function') {
+      row = connectDragPreview(row)
     }
 
     return this.connectDND(row)

--- a/src/files/table.js
+++ b/src/files/table.js
@@ -9,23 +9,28 @@ import { fileSize } from './utils.js'
 
 class RawTableFile extends BaseFile {
   render() {
+    const {
+      isDragging, isDeleting, isRenaming, isOver, isSelected,
+      action, url, browserProps, connectDragPreview,
+      depth, size, modified,
+    } = this.props
     let icon
     if (this.isImage()) {
-      icon = (<i className="fa fa-file-image-o" aria-hidden="true" />)
+      icon = browserProps.icons.Image
     } else if (this.isPdf()) {
-      icon = (<i className="fa fa-file-pdf-o" aria-hidden="true" />)
+      icon = browserProps.icons.PDF
     } else {
-      icon = (<i className="fa fa-file-o" aria-hidden="true" />)
+      icon = browserProps.icons.File
     }
 
-    const inAction = (this.props.isDragging || this.props.action)
+    const inAction = (isDragging || action)
 
     let name
-    if (!inAction && this.props.isDeleting) {
+    if (!inAction && isDeleting) {
       name = (
         <form className="deleting" onSubmit={this.handleDeleteSubmit}>
           <a
-            href={this.props.url || '#'}
+            href={url || '#'}
             download="download"
             onClick={this.handleFileClick}
           >
@@ -39,7 +44,7 @@ class RawTableFile extends BaseFile {
           </div>
         </form>
       )
-    } else if (!inAction && this.props.isRenaming) {
+    } else if (!inAction && isRenaming) {
       name = (
         <form className="renaming" onSubmit={this.handleRenameSubmit}>
           {icon}
@@ -56,7 +61,7 @@ class RawTableFile extends BaseFile {
     } else {
       name = (
         <a
-          href={this.props.url || '#'}
+          href={url || '#'}
           download="download"
           onClick={this.handleFileClick}
         >
@@ -71,29 +76,29 @@ class RawTableFile extends BaseFile {
         {name}
       </div>
     )
-    if (typeof this.props.browserProps.moveFile === 'function') {
-      draggable = this.props.connectDragPreview(draggable)
+    if (typeof browserProps.moveFile === 'function') {
+      draggable = connectDragPreview(draggable)
     }
 
     let row = (
       <tr
         className={ClassNames('file', {
-          pending: (this.props.action),
-          dragging: (this.props.isDragging),
-          dragover: (this.props.isOver),
-          selected: (this.props.isSelected),
+          pending: action,
+          dragging: isDragging,
+          dragover: isOver,
+          selected: isSelected,
         })}
         onClick={this.handleItemClick}
         onDoubleClick={this.handleItemDoubleClick}
       >
         <td className="name">
-          <div style={{paddingLeft: (this.props.depth * 16) + 'px'}}>
+          <div style={{paddingLeft: (depth * 16) + 'px'}}>
             {draggable}
           </div>
         </td>
-        <td className="size">{fileSize(this.props.size)}</td>
+        <td className="size">{fileSize(size)}</td>
         <td className="modified">
-          {typeof this.props.modified === 'undefined' ? '-' : Moment(this.props.modified, 'x').fromNow()}
+          {typeof modified === 'undefined' ? '-' : Moment(modified, 'x').fromNow()}
         </td>
       </tr>
     )

--- a/src/folders/list-thumbnail.js
+++ b/src/folders/list-thumbnail.js
@@ -8,16 +8,20 @@ import { BaseFileConnectors } from './../base-file.js'
 
 class RawListThumbnailFolder extends BaseFolder {
   render() {
-    const icon = (<i className={`fa fa-folder${this.props.isOpen ? '-open' : ''}-o`} aria-hidden="true" />)
+    const {
+      isOpen, isDragging, isDeleting, isRenaming, isDraft, isOver, isSelected,
+      url, action, browserProps, depth, keyDerived, connectDragPreview,
+    } = this.props
 
-    const inAction = (this.props.isDragging || this.props.action)
+    const icon = browserProps.icons[isOpen ? 'FolderOpen' : 'Folder']
+    const inAction = (isDragging || action)
 
     let name
-    if (!inAction && this.props.isDeleting) {
+    if (!inAction && isDeleting) {
       name = (
         <form className="deleting" onSubmit={this.handleDeleteSubmit}>
           <a
-            href={this.props.url}
+            href={url}
             download="download"
             onClick={this.handleFileClick}
           >
@@ -30,7 +34,7 @@ class RawListThumbnailFolder extends BaseFolder {
           </div>
         </form>
       )
-    } else if ((!inAction && this.props.isRenaming) || this.props.isDraft) {
+    } else if ((!inAction && isRenaming) || isDraft) {
       name = (
         <div>
           <form className="renaming" onSubmit={this.handleRenameSubmit}>
@@ -56,32 +60,32 @@ class RawListThumbnailFolder extends BaseFolder {
     }
 
     let children
-    if (this.props.isOpen && this.props.browserProps.nestChildren) {
+    if (isOpen && browserProps.nestChildren) {
       children = []
-      for (let childIndex = 0; childIndex < this.props.children.length; childIndex++) {
-        const file = this.props.children[childIndex]
+      for (let childIndex = 0; childIndex < children.length; childIndex++) {
+        const file = children[childIndex]
 
         const thisItemProps = {
-          ...this.props.browserProps.getItemProps(file, this.props.browserProps),
-          depth: this.props.depth + 1,
+          ...browserProps.getItemProps(file, browserProps),
+          depth: depth + 1,
         }
 
         if (file.size) {
           children.push(
-            <this.props.browserProps.fileRenderer
+            <browserProps.fileRenderer
               {...file}
               {...thisItemProps}
-              browserProps={this.props.browserProps}
-              {...this.props.browserProps.fileRendererProps}
+              browserProps={browserProps}
+              {...browserProps.fileRendererProps}
             />
           )
         } else {
           children.push(
-            <this.props.browserProps.folderRenderer
+            <browserProps.folderRenderer
               {...file}
               {...thisItemProps}
-              browserProps={this.props.browserProps}
-              {...this.props.browserProps.folderRendererProps}
+              browserProps={browserProps}
+              {...browserProps.folderRendererProps}
             />
           )
         }
@@ -96,11 +100,11 @@ class RawListThumbnailFolder extends BaseFolder {
     let folder = (
       <li
         className={ClassNames('folder', {
-          expanded: (this.props.isOpen && this.props.browserProps.nestChildren),
-          pending: (this.props.action),
-          dragging: (this.props.isDragging),
-          dragover: this.props.isOver,
-          selected: this.props.isSelected,
+          expanded: isOpen && browserProps.nestChildren,
+          pending: action,
+          dragging: isDragging,
+          dragover: isOver,
+          selected: isSelected,
         })}
         onClick={this.handleFolderClick}
         onDoubleClick={this.handleFolderDoubleClick}
@@ -112,8 +116,8 @@ class RawListThumbnailFolder extends BaseFolder {
         {children}
       </li>
     )
-    if (typeof this.props.browserProps.moveFolder === 'function' && this.props.keyDerived) {
-      folder = this.props.connectDragPreview(folder)
+    if (typeof browserProps.moveFolder === 'function' && keyDerived) {
+      folder = connectDragPreview(folder)
     }
 
     return this.connectDND(folder)

--- a/src/folders/table.js
+++ b/src/folders/table.js
@@ -8,21 +8,20 @@ import { BaseFileConnectors } from './../base-file.js'
 
 class RawTableFolder extends BaseFolder {
   render() {
-    let icon
-    if (this.props.isOpen) {
-      icon = (<i className="fa fa-folder-open-o" aria-hidden="true" />)
-    } else {
-      icon = (<i className="fa fa-folder-o" aria-hidden="true" />)
-    }
+    const {
+      isOpen, isDragging, isDeleting, isRenaming, isDraft, isOver, isSelected,
+      action, url, browserProps, connectDragPreview, depth,
+    } = this.props
 
-    const inAction = (this.props.isDragging || this.props.action)
+    const icon = browserProps.icons[isOpen ? 'FolderOpen' : 'Folder']
+    const inAction = (isDragging || action)
 
     let name
-    if (!inAction && this.props.isDeleting) {
+    if (!inAction && isDeleting) {
       name = (
         <form className="deleting" onSubmit={this.handleDeleteSubmit}>
           <a
-            href={this.props.url}
+            href={url}
             download="download"
             onClick={this.handleFileClick}
           >
@@ -36,7 +35,7 @@ class RawTableFolder extends BaseFolder {
           </div>
         </form>
       )
-    } else if ((!inAction && this.props.isRenaming) || this.props.isDraft) {
+    } else if ((!inAction && isRenaming) || isDraft) {
       name = (
         <div>
           <form className="renaming" onSubmit={this.handleRenameSubmit}>
@@ -63,23 +62,23 @@ class RawTableFolder extends BaseFolder {
       )
     }
 
-    if (typeof this.props.browserProps.moveFolder === 'function') {
-      name = this.props.connectDragPreview(name)
+    if (typeof browserProps.moveFolder === 'function') {
+      name = connectDragPreview(name)
     }
 
     const folder = (
       <tr
         className={ClassNames('folder', {
-          pending: (this.props.action),
-          dragging: (this.props.isDragging),
-          dragover: this.props.isOver,
-          selected: this.props.isSelected,
+          pending: action,
+          dragging: isDragging,
+          dragover: isOver,
+          selected: isSelected,
         })}
         onClick={this.handleFolderClick}
         onDoubleClick={this.handleFolderDoubleClick}
       >
         <td className="name">
-          <div style={{paddingLeft: (this.props.depth * 16) + 'px'}}>
+          <div style={{paddingLeft: (depth * 16) + 'px'}}>
             {name}
           </div>
         </td>

--- a/src/icons/FontAwesome.js
+++ b/src/icons/FontAwesome.js
@@ -1,0 +1,64 @@
+import React from 'react'
+
+// See https://allthingssmitty.com/2016/09/12/checking-if-font-awesome-loaded/
+const IsFontAwesomeLoaded = (version) => {
+  const prefix = version === 4 ? 'fa' : 'fas'
+  const fontNames = version === 4
+    ? ['FontAwesome', '"FontAwesome"']
+    : ['"Font Awesome 5 Free"', '"Font Awesome 5 Pro"']
+  let FontAwesomeLoaded = false
+  const span = document.createElement('span')
+
+  span.className = prefix
+  span.style.display = 'none'
+  document.body.insertBefore(span, document.body.firstChild)
+
+  const css = (element, property) => window.getComputedStyle(element, null).getPropertyValue(property)
+
+  if (!fontNames.includes(css(span, 'font-family'))) {
+    console.warn(
+      `Font Awesome ${version} was not detected but Font Awesome ${version} icons have been requested for \`react-object-list\``,
+    )
+  } else {
+    FontAwesomeLoaded = true
+  }
+  document.body.removeChild(span)
+  return FontAwesomeLoaded
+}
+
+const FontAwesomeIcons = (majorVersion = 4) => {
+  switch (majorVersion) {
+    case 4:
+      IsFontAwesomeLoaded(4)
+      return {
+        File: <i className="fa fa-file-o" aria-hidden="true" />,
+        Image: <i className="fa fa-file-image-o" aria-hidden="true" />,
+        PDF: <i className="fa fa-file-pdf-o" aria-hidden="true" />,
+        Rename: <i className="fa fa-i-cursor" aria-hidden="true" />,
+        Folder: <i className="fa fa-folder-o" aria-hidden="true" />,
+        FolderOpen: <i className="fa fa-folder-open-o" aria-hidden="true" />,
+        Delete: <i className="fa fa-trash-o" aria-hidden="true" />,
+        Loading: <i className="fa fa-circle-o-notch fa-spin" aria-hidden="true" />,
+      }
+    case 5:
+      IsFontAwesomeLoaded(5)
+      return {
+        File: <i className="far fa-file" aria-hidden="true" />,
+        Image: <i className="far fa-file-image" aria-hidden="true" />,
+        PDF: <i className="far fa-file-pdf" aria-hidden="true" />,
+        Rename: <i className="far fa-i-cursor" aria-hidden="true" />,
+        Folder: <i className="far fa-folder" aria-hidden="true" />,
+        FolderOpen: <i className="far fa-folder-open" aria-hidden="true" />,
+        Delete: <i className="far fa-trash-alt" aria-hidden="true" />,
+        Loading: <i className="fas fa-circle-notch fa-spin" aria-hidden="true" />,
+      }
+    default:
+      console.warn(
+        `Could not find config for version ${majorVersion}`,
+        'Accepted versions are: 4, 5',
+        'Please make an issue in `react-object-list` to fix this.'
+      )
+  }
+}
+
+export default FontAwesomeIcons

--- a/src/icons/index.js
+++ b/src/icons/index.js
@@ -1,0 +1,1 @@
+export FontAwesome from './FontAwesome'

--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,7 @@ import * as Details from './details'
 import * as Filters from './filters'
 import * as Groupers from './groupers'
 import * as Sorters from './sorters'
+import * as Icons from './icons'
 
 export default FileBrowser
 export {
@@ -28,4 +29,5 @@ export {
   Filters,
   Groupers,
   Sorters,
+  Icons,
 }


### PR DESCRIPTION
Fixes #26
Remove dependency on font awesome 4 by allowing users to specify their own icons using the icons prop.
i.e.
```
<FileBrowser icons={{FavouritesIcon: <MyFavourites />}} />
```

Defaults added for FA4 FA5, use:
```
import {FontAwesome} from 'react-keyed-file-browser'
<FileBrowser icons={FontAwesome(5)} />
```
This will check if the required version of font awesome is loaded in the DOM and warn if not.
Either way it'll apply the icons you picked (so as not to cause problems for false negatives)