### PR TITLE
Change message when no files are visible to dynamic - use props.

### DIFF
--- a/src/browser.js
+++ b/src/browser.js
@@ -37,7 +37,7 @@ class RawFileBrowser extends React.Component {
     actions: PropTypes.node,
     showActionBar: PropTypes.bool.isRequired,
     canFilter: PropTypes.bool.isRequired,
-    noFileMessage: PropTypes.string,
+    noFilesMessage: PropTypes.string,
 
     group: PropTypes.func.isRequired,
     sort: PropTypes.func.isRequired,
@@ -85,7 +85,7 @@ class RawFileBrowser extends React.Component {
   static defaultProps = {
     showActionBar: true,
     canFilter: true,
-    noFileMessage: 'No files.',
+    noFilesMessage: 'No files.',
 
     group: GroupByFolder,
     sort: SortByName,
@@ -631,7 +631,7 @@ class RawFileBrowser extends React.Component {
           } else {
             contents = (<tr>
               <td colSpan="100">
-                {this.props.noFileMessage}
+                {this.props.noFilesMessage}
               </td>
             </tr>)
           }

--- a/src/browser.js
+++ b/src/browser.js
@@ -37,6 +37,7 @@ class RawFileBrowser extends React.Component {
     actions: PropTypes.node,
     showActionBar: PropTypes.bool.isRequired,
     canFilter: PropTypes.bool.isRequired,
+    noFileMessage: PropTypes.string,
 
     group: PropTypes.func.isRequired,
     sort: PropTypes.func.isRequired,
@@ -84,6 +85,7 @@ class RawFileBrowser extends React.Component {
   static defaultProps = {
     showActionBar: true,
     canFilter: true,
+    noFileMessage: 'No files.',
 
     group: GroupByFolder,
     sort: SortByName,
@@ -629,7 +631,7 @@ class RawFileBrowser extends React.Component {
           } else {
             contents = (<tr>
               <td colSpan="100">
-                No files.
+                {this.props.noFileMessage}
               </td>
             </tr>)
           }


### PR DESCRIPTION
Message displayed when there were no files to display was static. The old message is stored as a default prop, new messages can be controlled through the `noFileMessage` prop.