### PR TITLE
String refs (legacy) -> callback refs

### DIFF
--- a/src/base-file.js
+++ b/src/base-file.js
@@ -38,10 +38,10 @@ class BaseFile extends React.Component {
   componentDidUpdate(oldProps, oldState) {
     if (!oldProps.isRenaming && this.props.isRenaming) {
       window.requestAnimationFrame(() => {
-        const currentName = this.refs.newName.value
+        const currentName = this.newNameRef.value
         const pointIndex = currentName.lastIndexOf('.')
-        this.refs.newName.setSelectionRange(0, pointIndex || currentName.length)
-        this.refs.newName.focus()
+        this.newNameRef.setSelectionRange(0, pointIndex || currentName.length)
+        this.newNameRef.focus()
       })
     }
   }
@@ -99,7 +99,7 @@ class BaseFile extends React.Component {
     this.props.browserProps.beginAction('rename', this.props.fileKey)
   }
   handleNewNameChange = (event) => {
-    const newName = this.refs.newName.value
+    const newName = this.newNameRef.value
     this.setState({newName: newName})
   }
   handleRenameSubmit = (event) => {

--- a/src/base-folder.js
+++ b/src/base-folder.js
@@ -49,9 +49,9 @@ class BaseFolder extends React.Component {
   }
   selectAllNewName = () => {
     window.requestAnimationFrame(() => {
-      const currentName = this.refs.newName.value
-      this.refs.newName.setSelectionRange(0, currentName.length)
-      this.refs.newName.focus()
+      const currentName = this.newNameRef.value
+      this.newNameRef.setSelectionRange(0, currentName.length)
+      this.newNameRef.focus()
     })
   }
 
@@ -79,7 +79,7 @@ class BaseFolder extends React.Component {
     this.props.browserProps.beginAction('rename', this.props.fileKey)
   }
   handleNewNameChange = (event) => {
-    const newName = this.refs.newName.value
+    const newName = this.newNameRef.value
     this.setState({newName: newName})
   }
   handleRenameSubmit = (event) => {

--- a/src/browser.js
+++ b/src/browser.js
@@ -726,7 +726,7 @@ class RawFileBrowser extends React.Component {
     return (
       <div className="rendered-react-keyed-file-browser">
         {this.props.actions}
-        <div className="rendered-file-browser" ref={el => this.browserRef = el}>
+        <div className="rendered-file-browser" ref={el => { this.browserRef = el }}>
           {this.props.showActionBar && this.renderActionBar(selectedItem)}
           <div className="files">
             {renderedFiles}

--- a/src/browser.js
+++ b/src/browser.js
@@ -287,10 +287,11 @@ class RawFileBrowser extends React.Component {
 
   // event handlers
   handleGlobalClick = (event) => {
-    const inBrowser = !!(this.refs.browser.contains(event.target))
-    const inPreview = !!(
-      typeof this.refs.preview !== 'undefined' && this.refs.preview.contains(event.target)
-    )
+    const inBrowser = !!(this.browserRef && this.browserRef.contains(event.target))
+
+    // TODO: updated old-to-new ref styles, but this ref was never set
+    const inPreview = !!(this.previewRef && this.previewRef.contains(event.target))
+
     if (!inBrowser && !inPreview) {
       this.setState(state => {
         state.selection = null
@@ -725,7 +726,7 @@ class RawFileBrowser extends React.Component {
     return (
       <div className="rendered-react-keyed-file-browser">
         {this.props.actions}
-        <div className="rendered-file-browser" ref="browser">
+        <div className="rendered-file-browser" ref={el => this.browserRef = el}>
           {this.props.showActionBar && this.renderActionBar(selectedItem)}
           <div className="files">
             {renderedFiles}

--- a/src/files/list-thumbnail.js
+++ b/src/files/list-thumbnail.js
@@ -61,7 +61,7 @@ class RawListThumbnailFile extends BaseFile {
         name = (
           <form className="renaming" onSubmit={this.handleRenameSubmit}>
             <input
-              ref={el => this.newNameRef = el}
+              ref={el => { this.newNameRef = el }}
               type="text"
               value={this.state.newName}
               onChange={this.handleNewNameChange}

--- a/src/files/list-thumbnail.js
+++ b/src/files/list-thumbnail.js
@@ -61,7 +61,7 @@ class RawListThumbnailFile extends BaseFile {
         name = (
           <form className="renaming" onSubmit={this.handleRenameSubmit}>
             <input
-              ref="newName"
+              ref={el => this.newNameRef = el}
               type="text"
               value={this.state.newName}
               onChange={this.handleNewNameChange}

--- a/src/files/table.js
+++ b/src/files/table.js
@@ -49,7 +49,7 @@ class RawTableFile extends BaseFile {
         <form className="renaming" onSubmit={this.handleRenameSubmit}>
           {icon}
           <input
-            ref={el => this.newNameRef = el}
+            ref={el => { this.newNameRef = el }}
             type="text"
             value={this.state.newName}
             onChange={this.handleNewNameChange}

--- a/src/files/table.js
+++ b/src/files/table.js
@@ -49,7 +49,7 @@ class RawTableFile extends BaseFile {
         <form className="renaming" onSubmit={this.handleRenameSubmit}>
           {icon}
           <input
-            ref="newName"
+            ref={el => this.newNameRef = el}
             type="text"
             value={this.state.newName}
             onChange={this.handleNewNameChange}

--- a/src/filters/default.js
+++ b/src/filters/default.js
@@ -8,7 +8,7 @@ class Filter extends React.Component {
   }
 
   handleFilterChange = (event) => {
-    const newValue = this.refs.filter.value
+    const newValue = this.filterRef.value
     this.props.updateFilter(newValue)
   }
 
@@ -16,6 +16,7 @@ class Filter extends React.Component {
     return (
       <input
         ref="filter"
+        ref={el => this.filterRef = el}
         type="search"
         placeholder="Filter files"
         value={this.props.value}

--- a/src/filters/default.js
+++ b/src/filters/default.js
@@ -16,7 +16,7 @@ class Filter extends React.Component {
     return (
       <input
         ref="filter"
-        ref={el => this.filterRef = el}
+        ref={el => { this.filterRef = el }}
         type="search"
         placeholder="Filter files"
         value={this.props.value}

--- a/src/folders/list-thumbnail.js
+++ b/src/folders/list-thumbnail.js
@@ -40,7 +40,7 @@ class RawListThumbnailFolder extends BaseFolder {
           <form className="renaming" onSubmit={this.handleRenameSubmit}>
             <input
               type="text"
-              ref={el => this.newNameRef = el}
+              ref={el => { this.newNameRef = el }}
               value={this.state.newName}
               onChange={this.handleNewNameChange}
               onBlur={this.handleCancelEdit}

--- a/src/folders/list-thumbnail.js
+++ b/src/folders/list-thumbnail.js
@@ -40,7 +40,7 @@ class RawListThumbnailFolder extends BaseFolder {
           <form className="renaming" onSubmit={this.handleRenameSubmit}>
             <input
               type="text"
-              ref="newName"
+              ref={el => this.newNameRef = el}
               value={this.state.newName}
               onChange={this.handleNewNameChange}
               onBlur={this.handleCancelEdit}

--- a/src/folders/table.js
+++ b/src/folders/table.js
@@ -42,7 +42,7 @@ class RawTableFolder extends BaseFolder {
             {icon}
             <input
               type="text"
-              ref={el => this.newNameRef = el}
+              ref={el => { this.newNameRef = el }}
               value={this.state.newName}
               onChange={this.handleNewNameChange}
               onBlur={this.handleCancelEdit}

--- a/src/folders/table.js
+++ b/src/folders/table.js
@@ -42,7 +42,7 @@ class RawTableFolder extends BaseFolder {
             {icon}
             <input
               type="text"
-              ref="newName"
+              ref={el => this.newNameRef = el}
               value={this.state.newName}
               onChange={this.handleNewNameChange}
               onBlur={this.handleCancelEdit}


### PR DESCRIPTION
The use of [legacy string refs](https://reactjs.org/docs/refs-and-the-dom.html#legacy-api-string-refs) prevented me from making any edits, as noted in #34. This should bring the ref usage up to the modern era without making any functional changes.