### PR TITLE
Adding interaction callbacks

### DIFF
--- a/src/base-file.js
+++ b/src/base-file.js
@@ -73,9 +73,8 @@ class BaseFile extends React.Component {
   }
 
   handleFileClick = (event) => {
-    if (event) {
-      event.preventDefault()
-    }
+    event && event.preventDefault()
+
     this.props.browserProps.preview({
       url: this.props.url,
       name: this.getName(),
@@ -85,7 +84,7 @@ class BaseFile extends React.Component {
   }
   handleItemClick = (event) => {
     event.stopPropagation()
-    this.props.browserProps.select(this.props.fileKey)
+    this.props.browserProps.select(this.props.fileKey, 'file')
   }
   handleItemDoubleClick = (event) => {
     event.stopPropagation()
@@ -176,7 +175,7 @@ class BaseFile extends React.Component {
 
 const dragSource = {
   beginDrag(props) {
-    props.browserProps.select(props.fileKey)
+    props.browserProps.select(props.fileKey, 'file')
     return {
       key: props.fileKey,
     }

--- a/src/base-folder.js
+++ b/src/base-folder.js
@@ -65,7 +65,7 @@ class BaseFolder extends React.Component {
 
   handleFolderClick = (event) => {
     event.stopPropagation()
-    this.props.browserProps.select(this.props.fileKey)
+    this.props.browserProps.select(this.props.fileKey, 'folder')
   }
   handleFolderDoubleClick = (event) => {
     event.stopPropagation()
@@ -166,7 +166,7 @@ class BaseFolder extends React.Component {
 
 const dragSource = {
   beginDrag(props) {
-    props.browserProps.select(props.fileKey)
+    props.browserProps.select(props.fileKey, 'folder')
     return {
       key: props.fileKey,
     }


### PR DESCRIPTION
Adds callbacks for:
-    onSelect          `// Always called when a file or folder is selected`
-    onSelectFile      `//    Called after onSelect, only on file selection`
-    onSelectFolder    `//    Called after onSelect, only on folder selection`
-    onPreviewOpen     `// File opened`
-    onPreviewClose    `// File closed`
-    onFolderOpen      `// Folder opened`
-    onFolderClose     `// Folder closed`

Allow customizing interactivity of the file browser without requiring overriding the renderers. Specifically for me, this enabled me to trigger loading each subfolder's files dynamically from S3 whenever a folder is opened. I believe the addition of callback hooks will also greatly ease e.g. #35. 
