### PR TITLE
Improvement on drag events

### DIFF
--- a/src/base-file.js
+++ b/src/base-file.js
@@ -188,9 +188,9 @@ const dragSource = {
     const fileNameParts = props.fileKey.split('/')
     const fileName = fileNameParts[fileNameParts.length - 1]
     const newKey = `${dropResult.path}${fileName}`
-    if (newKey !== props.fileKey && props.browserProps.renameFile) {
+    if (newKey !== props.fileKey && props.browserProps.moveFile) {
       props.browserProps.openFolder(dropResult.path)
-      props.browserProps.renameFile(props.fileKey, newKey)
+      props.browserProps.moveFile(props.fileKey, newKey)
     }
   },
 }

--- a/src/base-folder.js
+++ b/src/base-folder.js
@@ -186,9 +186,9 @@ const dragSource = {
     // abort if the new folder name contains itself
     if (newKey.substr(0, props.fileKey.length) === props.fileKey) return
 
-    if (newKey !== props.fileKey && props.browserProps.renameFolder) {
+    if (newKey !== props.fileKey && props.browserProps.moveFolder) {
       props.browserProps.openFolder(dropResult.path)
-      props.browserProps.renameFolder(props.fileKey, newKey)
+      props.browserProps.moveFolder(props.fileKey, newKey)
     }
   },
 }


### PR DESCRIPTION
The drag event fires the onRenameFile / onRenameFolder functions, but this way it was not possible to identify whether the user is performing a name change or a drag action. With this change it will be possible to collect these two actions without impacting the existing functionalities.