### PR TITLE
UP-1895 Documents - no more backslash havoc

### DIFF
--- a/demo-site/nested-editable.js
+++ b/demo-site/nested-editable.js
@@ -54,12 +54,14 @@ class NestedEditableDemo extends React.Component {
     })
   }
   handleCreateFiles = (files, prefix) => {
-    this.setState(state => {
+    this.setState(prevState => {
       const newFiles = files.map((file) => {
         let newKey = prefix
         if (prefix !== '' && prefix.substring(prefix.length - 1, prefix.length) !== '/') {
           newKey += '/'
         }
+        const invalidChar = ['/', '\\']
+        if (invalidChar.some(char => file.name.indexOf(char) !== -1)) return
         newKey += file.name
         return {
           key: newKey,
@@ -67,21 +69,13 @@ class NestedEditableDemo extends React.Component {
           modified: +Moment(),
         }
       })
-
       const uniqueNewFiles = []
-      newFiles.map((newFile) => {
-        let exists = false
-        state.files.map((existingFile) => {
-          if (existingFile.key === newFile.key) {
-            exists = true
-          }
-        })
-        if (!exists) {
-          uniqueNewFiles.push(newFile)
-        }
+      newFiles.forEach((newFile) => {
+        const exists = prevState.files.some(existingFile => (existingFile.key === newFile.key))
+        if (!exists) uniqueNewFiles.push(newFile)
       })
-      state.files = state.files.concat(uniqueNewFiles)
-      return state
+      const updatedFiles = [...prevState.files, uniqueNewFiles]
+      return { files: updatedFiles }
     })
   }
   handleRenameFolder = (oldKey, newKey) => {

--- a/src/base-file.js
+++ b/src/base-file.js
@@ -65,7 +65,6 @@ class BaseFile extends React.Component {
 
   handleFileClick = (event) => {
     event && event.preventDefault()
-
     this.props.browserProps.preview({
       url: this.props.url,
       name: this.getName(),

--- a/src/base-file.js
+++ b/src/base-file.js
@@ -108,15 +108,14 @@ class BaseFile extends React.Component {
       // })
       return
     }
-    if (newName.indexOf('/') !== -1) {
-      // todo: move to props handler
-      // window.notify({
-      //   style: 'error',
-      //   title: 'Invalid new file name',
-      //   body: 'File names cannot contain forward slashes.',
-      // })
-      return
-    }
+    const invalidChar = ['/', '\\']
+    if (invalidChar.some(char => newName.indexOf(char) !== -1)) return
+    // todo: move to props handler
+    // window.notify({
+    //   style: 'error',
+    //   title: 'Invalid new file name',
+    //   body: 'File names cannot contain forward slashes.',
+    // })
     let newKey = newName
     const slashIndex = this.props.fileKey.lastIndexOf('/')
     if (slashIndex !== -1) {

--- a/src/base-folder.js
+++ b/src/base-folder.js
@@ -97,15 +97,15 @@ class BaseFolder extends React.Component {
       // })
       return
     }
-    if (newName.indexOf('/') !== -1) {
-      // todo: move to props handler
-      // window.notify({
-      //   style: 'error',
-      //   title: 'Invalid new folder name',
-      //   body: 'Folder names cannot contain forward slashes.',
-      // })
-      return
-    }
+    const invalidChar = ['/', '\\']
+    if (invalidChar.some(char => newName.indexOf(char) !== -1)) return
+    // todo: move to props handler
+    // window.notify({
+    //   style: 'error',
+    //   title: 'Invalid new folder name',
+    //   body: 'Folder names cannot contain forward slashes.',
+    // })
+
     let newKey = this.props.fileKey.substr(0, this.props.fileKey.substr(0, this.props.fileKey.length - 1).lastIndexOf('/'))
     if (newKey.length) {
       newKey += '/'

--- a/src/base-folder.js
+++ b/src/base-folder.js
@@ -80,7 +80,7 @@ class BaseFolder extends React.Component {
   }
   handleNewNameChange = (event) => {
     const newName = this.newNameRef.value
-    this.setState({newName: newName})
+    this.setState({ newName: newName })
   }
   handleRenameSubmit = (event) => {
     event.preventDefault()


### PR DESCRIPTION
JIRA PBI https://uptickhq.atlassian.net/browse/UP-1895 
**STATUS: DO NOT MERGE**

Backslashes in folder/file names resulting in:
- unable to rename
- unable to re-sort
- unable to delete

Fixes:
[x] On creation of a new folder, backslashes are no longer allowed
[x] Old folders with a backslash can now be renamed
[x] Subfolders are not allowed forward/back slashes
[ ]  On creation of a new file, backslashes are no longer allowed
[ ] Old files with a backslash can now be renamed
[ ] Folders/Files with backslashes can now be re-sorted
