### PR TITLE
wrap onCreateFolder callback

### DIFF
--- a/src/browser.js
+++ b/src/browser.js
@@ -182,7 +182,9 @@ class RawFileBrowser extends React.Component {
       activeAction: null,
       actionTarget: null,
       selection: key,
-    }, this.props.onCreateFolder(key))
+    }, () => {
+      this.props.onCreateFolder(key)
+    })
   }
 
   moveFile = (oldKey, newKey) => {


### PR DESCRIPTION
The other callbacks are wrapped, so not sure if you just missed this one. Without wrapping it I get an error if my callback returns a promise.