### PR TITLE
Make browserProps available on ActionRenderer

### DIFF
--- a/src/browser.js
+++ b/src/browser.js
@@ -481,6 +481,7 @@ class RawFileBrowser extends React.Component {
       onCreateFolder, onRenameFile, onRenameFolder,
       onDeleteFile, onDeleteFolder, onDownloadFile,
     } = this.props
+    const browserProps = this.getBrowserProps()
     const selectionIsFolder = (selectedItem && !selectedItem.size)
     let filter
     if (canFilter) {
@@ -495,6 +496,8 @@ class RawFileBrowser extends React.Component {
 
     let actions = (
       <ActionRenderer
+        browserProps={browserProps}
+
         selectedItem={selectedItem}
         isFolder={selectionIsFolder}
 


### PR DESCRIPTION
the other renderers have it and can be very useful when using a
user-defined ActionRenderer

Personally I found this useful because I'm using a custom ActionRenderer to translate the action buttons to my language and style the buttons, but now I wan to add a new button to the action bar and this allows me to pass a new prop to <FileBrowser/> and have it available on ActionRenderer via browserProps