### PR TITLE
Expose a confirmDeletionRenderer prop for FileBrowser

### DIFF
--- a/src/browser.js
+++ b/src/browser.js
@@ -12,6 +12,7 @@ import { DefaultFilter } from './filters'
 import { TableHeader } from './headers'
 import { TableFile } from './files'
 import { TableFolder } from './folders'
+import { DefaultConfirmDeletion } from './confirmations'
 
 // default processors
 import { GroupByFolder } from './groupers'
@@ -76,6 +77,7 @@ class RawFileBrowser extends React.Component {
     detailRenderer: PropTypes.func,
     detailRendererProps: PropTypes.object,
     actionRenderer: PropTypes.func,
+    confirmDeletionRenderer: PropTypes.func,
 
     onCreateFiles: PropTypes.oneOfType([PropTypes.func, PropTypes.bool]),
     onCreateFolder: PropTypes.oneOfType([PropTypes.func, PropTypes.bool]),
@@ -122,6 +124,7 @@ class RawFileBrowser extends React.Component {
     detailRenderer: DefaultDetail,
     detailRendererProps: {},
     actionRenderer: DefaultAction,
+    confirmDeletionRenderer: DefaultConfirmDeletion,
 
     icons: {},
 
@@ -442,6 +445,7 @@ class RawFileBrowser extends React.Component {
       fileRendererProps: this.props.fileRendererProps,
       folderRenderer: this.props.folderRenderer,
       folderRendererProps: this.props.folderRendererProps,
+      confirmDeletionRenderer: this.props.confirmDeletionRenderer,
       icons: this.props.icons,
 
       // browser state

--- a/src/confirmations/default.js
+++ b/src/confirmations/default.js
@@ -1,0 +1,41 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+const ConfirmDeletion = (props) => {
+  const {
+    children,
+    handleDeleteSubmit,
+    handleFileClick,
+    url,
+  } = props
+
+  return (
+    <form className="deleting" onSubmit={handleDeleteSubmit}>
+      <a
+        href={url}
+        download="download"
+        onClick={handleFileClick}
+      >
+        {children}
+      </a>
+      <div>
+        <button type="submit">
+          Confirm Deletion
+        </button>
+      </div>
+    </form>
+  )
+}
+
+ConfirmDeletion.propTypes = {
+  children: PropTypes.node,
+  handleDeleteSubmit: PropTypes.func,
+  handleFileClick: PropTypes.func,
+  url: PropTypes.string,
+}
+
+ConfirmDeletion.defaultProps = {
+  url: '#',
+}
+
+export default ConfirmDeletion

--- a/src/confirmations/index.js
+++ b/src/confirmations/index.js
@@ -1,0 +1,5 @@
+import DefaultConfirmDeletion from './default'
+
+export {
+  DefaultConfirmDeletion,
+}

--- a/src/files/list-thumbnail.js
+++ b/src/files/list-thumbnail.js
@@ -21,6 +21,7 @@ class RawListThumbnailFile extends BaseFile {
       isDragging, isRenaming, isSelected, isSelectable, isOver, isDeleting,
       showName, showSize, showModified, browserProps, connectDragPreview,
     } = this.props
+
     let icon
     if (thumbnailUrl) {
       icon = (
@@ -34,24 +35,19 @@ class RawListThumbnailFile extends BaseFile {
 
     const inAction = (isDragging || action)
 
+    const ConfirmDeletionRenderer = browserProps.confirmDeletionRenderer
+
     let name
     if (showName) {
       if (!inAction && isDeleting) {
         name = (
-          <form className="deleting" onSubmit={this.handleDeleteSubmit}>
-            <a
-              href={url}
-              download="download"
-              onClick={this.handleFileClick}
-            >
-              {this.getName()}
-            </a>
-            <div>
-              <button type="submit">
-                Confirm Deletion
-              </button>
-            </div>
-          </form>
+          <ConfirmDeletionRenderer
+            handleDeleteSubmit={this.handleDeleteSubmit}
+            handleFileClick={this.handleFileClick}
+            url={url}
+          >
+            {this.getName()}
+          </ConfirmDeletionRenderer>
         )
       } else if (!inAction && isRenaming) {
         name = (

--- a/src/files/table.js
+++ b/src/files/table.js
@@ -18,24 +18,19 @@ class RawTableFile extends BaseFile {
     const icon = browserProps.icons[this.getFileType()] || browserProps.icons.File
     const inAction = (isDragging || action)
 
+    const ConfirmDeletionRenderer = browserProps.confirmDeletionRenderer
+
     let name
     if (!inAction && isDeleting) {
       name = (
-        <form className="deleting" onSubmit={this.handleDeleteSubmit}>
-          <a
-            href={url || '#'}
-            download="download"
-            onClick={this.handleFileClick}
-          >
-            {icon}
-            {this.getName()}
-          </a>
-          <div>
-            <button type="submit">
-              Confirm Deletion
-            </button>
-          </div>
-        </form>
+        <ConfirmDeletionRenderer
+          handleDeleteSubmit={this.handleDeleteSubmit}
+          handleFileClick={this.handleFileClick}
+          url={url}
+        >
+          {icon}
+          {this.getName()}
+        </ConfirmDeletionRenderer>
       )
     } else if (!inAction && isRenaming) {
       name = (

--- a/src/folders/list-thumbnail.js
+++ b/src/folders/list-thumbnail.js
@@ -16,25 +16,21 @@ class RawListThumbnailFolder extends BaseFolder {
     } = this.props
 
     const icon = browserProps.icons[isOpen ? 'FolderOpen' : 'Folder']
+
     const inAction = (isDragging || action)
+
+    const ConfirmDeletionRenderer = browserProps.confirmDeletionRenderer
 
     let name
     if (!inAction && isDeleting) {
       name = (
-        <form className="deleting" onSubmit={this.handleDeleteSubmit}>
-          <a
-            href={url}
-            download="download"
-            onClick={this.handleFileClick}
-          >
-            {this.getName()}
-          </a>
-          <div>
-            <button type="submit">
-              Confirm Deletion
-            </button>
-          </div>
-        </form>
+        <ConfirmDeletionRenderer
+          handleDeleteSubmit={this.handleDeleteSubmit}
+          handleFileClick={this.handleFileClick}
+          url={url}
+        >
+          {this.getName()}
+        </ConfirmDeletionRenderer>
       )
     } else if ((!inAction && isRenaming) || isDraft) {
       name = (

--- a/src/folders/table.js
+++ b/src/folders/table.js
@@ -16,24 +16,19 @@ class RawTableFolder extends BaseFolder {
     const icon = browserProps.icons[isOpen ? 'FolderOpen' : 'Folder']
     const inAction = (isDragging || action)
 
+    const ConfirmDeletionRenderer = browserProps.confirmDeletionRenderer
+
     let name
     if (!inAction && isDeleting) {
       name = (
-        <form className="deleting" onSubmit={this.handleDeleteSubmit}>
-          <a
-            href={url}
-            download="download"
-            onClick={this.handleFileClick}
-          >
-            {icon}
-            {this.getName()}
-          </a>
-          <div>
-            <button type="submit">
-              Confirm Deletion
-            </button>
-          </div>
-        </form>
+        <ConfirmDeletionRenderer
+          handleDeleteSubmit={this.handleDeleteSubmit}
+          handleFileClick={this.handleFileClick}
+          url={url}
+        >
+          {icon}
+          {this.getName()}
+        </ConfirmDeletionRenderer>
       )
     } else if ((!inAction && isRenaming) || isDraft) {
       name = (


### PR DESCRIPTION
This PR will address issue #82 in a manner outlined by contributor:  @jlo-1 .

This update exposes a new `confirmDeletionRenderer` prop to FileBrowser which takes in 4 props:  handleDeleteSubmit, handleFileClick, url, and children.

The old behavior is maintained and has been modularized out into `src/confirmations/default.js`.  The "Confirm Deletion" button component is used as the default if no `confirmDeletionRenderer` is passed in.

This is not a breaking API change and all things remain fully backwards compatible.