### PR TITLE
OSX compatible multiple selection

### DIFF
--- a/src/base-file.js
+++ b/src/base-file.js
@@ -74,7 +74,7 @@ class BaseFile extends React.Component {
   }
   handleItemClick = (event) => {
     event.stopPropagation()
-    this.props.browserProps.select(this.props.fileKey, 'file', event.ctrlKey, event.shiftKey)
+    this.props.browserProps.select(this.props.fileKey, 'file', event.ctrlKey || event.metaKey, event.shiftKey)
   }
   handleItemDoubleClick = (event) => {
     event.stopPropagation()

--- a/src/base-folder.js
+++ b/src/base-folder.js
@@ -66,7 +66,7 @@ class BaseFolder extends React.Component {
 
   handleFolderClick = (event) => {
     event.stopPropagation()
-    this.props.browserProps.select(this.props.fileKey, 'folder', event.ctrlKey, event.shiftKey)
+    this.props.browserProps.select(this.props.fileKey, 'folder', event.ctrlKey || event.metaKey, event.shiftKey)
   }
   handleFolderDoubleClick = (event) => {
     event.stopPropagation()


### PR DESCRIPTION
This PR adds the ability for the user to use either the ctrl or meta (cmd on mac) keys to select multiple rows. Please see #93 for more details.

Please let me know if there are tests/examples that should be updated as well in this PR. 

Thanks!

Resolves #93 
