### PR TITLE
Allow to create folders when onRenameFolder is not provided

### DIFF
--- a/src/base-folder.js
+++ b/src/base-folder.js
@@ -86,7 +86,7 @@ class BaseFolder extends React.Component {
   }
   handleRenameSubmit = (event) => {
     event.preventDefault()
-    if (!this.props.browserProps.renameFolder) {
+    if (!this.props.browserProps.renameFolder && !this.props.isDraft) {
       return
     }
     const newName = this.state.newName.trim()


### PR DESCRIPTION
The early return in handleRenameSubmit was only checking for
renameFolder presence but we don't need this to create a folder.

Maybe we should have a distinct handleCreateSubmit method and extract
common code in a helper function/private method.