### PR TITLE
Fix new folder and file creation spamming issues

### DIFF
--- a/src/browser.js
+++ b/src/browser.js
@@ -22,7 +22,7 @@ import { isFolder } from './utils'
 import { DefaultAction } from './actions'
 
 const SEARCH_RESULTS_PER_PAGE = 20
-const regexForNewFolderOrFileSelection = /.*\/__new__[\/]?$/gm
+const regexForNewFolderOrFileSelection = /.*\/__new__[/]?$/gm
 
 function getItemProps(file, browserProps) {
   return {

--- a/src/browser.js
+++ b/src/browser.js
@@ -22,6 +22,7 @@ import { isFolder } from './utils'
 import { DefaultAction } from './actions'
 
 const SEARCH_RESULTS_PER_PAGE = 20
+const regexForNewFolderOrFileSelection = /.*\/__new__[\/]?$/gm
 
 function getItemProps(file, browserProps) {
   return {
@@ -300,7 +301,9 @@ class RawFileBrowser extends React.Component {
   }
 
   endAction = () => {
-    if (this.state.selection !== null && this.state.selection.indexOf('__new__') !== -1) {
+    if (this.state.selection && this.state.selection.length > 0 && (
+      this.state.selection.filter((selection) => selection.match(regexForNewFolderOrFileSelection)).length > 0
+    )) {
       this.setState({ selection: [] })
     }
     this.beginAction(null, null)
@@ -417,19 +420,20 @@ class RawFileBrowser extends React.Component {
     }
     this.setState(prevState => {
       let addKey = ''
-      if (prevState.selection) {
+      if (prevState.selection && prevState.selection.length > 0) {
         addKey += prevState.selection
         if (addKey.substr(addKey.length - 1, addKey.length) !== '/') {
           addKey += '/'
         }
       }
-      addKey += '__new__/'
+
+      if (addKey !== '__new__/' && !addKey.endsWith('/__new__/')) addKey += '__new__/'
       const stateChanges = {
         actionTargets: [addKey],
         activeAction: 'createFolder',
         selection: [addKey],
       }
-      if (prevState.selection) {
+      if (prevState.selection && prevState.selection.length > 0) {
         stateChanges.openFolders = {
           ...prevState.openFolders,
           [this.state.selection]: true,


### PR DESCRIPTION
Fixes #108

* Place more aggressive checks to clear selection if new folder or file was being created and user aborts by clicking outside or any other way
* There was another issue on empty structure(no files or folder yet) if i tried to create a new folder, it was impossible, on the input field click it just focused out, this might had been some edge case happening for me only but i fixed it as well

PS: Its not the best fix possible, I patched this in a hurry for our internal use, but thought should contribute back in whatever state it is. Seems to work fine for us for now. I will keep posted if we discover any other issue.