### PR TITLE
issue/133 Added onDownloadFolder

### DIFF
--- a/src/actions/default.js
+++ b/src/actions/default.js
@@ -26,6 +26,9 @@ const Actions = (props) => {
     canDownloadFile,
     onDownloadFile,
 
+    canDownloadFolder,
+    onDownloadFolder,
+
   } = props
 
   /** @type any */
@@ -130,11 +133,11 @@ const Actions = (props) => {
         )
       }
 
-      if (!isFolder && canDownloadFile) {
+      if ((!isFolder && canDownloadFile) || (isFolder && canDownloadFolder)) {
         actions.push(
           <li key="action-download">
             <a
-              onClick={onDownloadFile}
+              onClick={isFolder ? onDownloadFolder : onDownloadFile}
               href="#"
               role="button"
             >
@@ -201,6 +204,9 @@ Actions.propTypes = {
 
   canDownloadFile: PropTypes.bool,
   onDownloadFile: PropTypes.func,
+
+  canDownloadFolder: PropTypes.bool,
+  onDownloadFolder: PropTypes.func,
 }
 
 Actions.defaultProps = {
@@ -226,6 +232,9 @@ Actions.defaultProps = {
 
   canDownloadFile: false,
   onDownloadFile: null,
+
+  canDownloadFolder: false,
+  onDownloadFolder: null,
 }
 
 export default Actions

--- a/src/browser.js
+++ b/src/browser.js
@@ -464,7 +464,7 @@ class RawFileBrowser extends React.Component {
     const files = this.getFiles()
     const selectedItems = this.getSelectedItems(files)
 
-    const selectionIsFolder = (selectedItems.length === 1 && isFolder(selectedItems[0]) && !selectedItems[0].size)
+    const selectionIsFolder = (selectedItems.length === 1 && isFolder(selectedItems[0]))
     if (selectionIsFolder) {
       this.downloadFolder(this.state.selection)
       return
@@ -531,7 +531,7 @@ class RawFileBrowser extends React.Component {
       onDownloadFolder,
     } = this.props
     const browserProps = this.getBrowserProps()
-    const selectionIsFolder = (selectedItems.length === 1 && isFolder(selectedItems[0]) && !selectedItems[0].size)
+    const selectionIsFolder = (selectedItems.length === 1 && isFolder(selectedItems[0]))
     let filter
     if (canFilter) {
       filter = (

--- a/src/browser.js
+++ b/src/browser.js
@@ -464,7 +464,7 @@ class RawFileBrowser extends React.Component {
     const files = this.getFiles()
     const selectedItems = this.getSelectedItems(files)
 
-    const selectionIsFolder = (selectedItems.length === 1 && !selectedItems[0].size)
+    const selectionIsFolder = (selectedItems.length === 1 && isFolder(selectedItems[0]) && !selectedItems[0].size)
     if (selectionIsFolder) {
       this.downloadFolder(this.state.selection)
       return
@@ -531,7 +531,7 @@ class RawFileBrowser extends React.Component {
       onDownloadFolder,
     } = this.props
     const browserProps = this.getBrowserProps()
-    const selectionIsFolder = (selectedItems.length === 1 && !selectedItems[0].size)
+    const selectionIsFolder = (selectedItems.length === 1 && isFolder(selectedItems[0]) && !selectedItems[0].size)
     let filter
     if (canFilter) {
       filter = (


### PR DESCRIPTION
resolve #133 

### Added
* `getFiles` function to encapsulate the `files` part of the `render` function
* `getSelectedItems` function to encapsulate the `selectedItems` part of the `render` function
* `canDownloadFolder` and `onDownloadFolder`  functions and their configs

### Changed
* `handleActionBarDownloadClick` function to check if the selection is a folder using new `getFiles` and `getSelectedItems` functions
* `render` function uses the new `getFiles` and `getSelectedItems` functions
* Switched to using `utils.isFolder` rather than a `size === 0` comparison for folders 
