### PR TITLE
onSelectFolder returns folder from file path instead of undefined

### DIFF
--- a/src/browser.js
+++ b/src/browser.js
@@ -175,7 +175,21 @@ class RawFileBrowser extends React.Component {
     window.removeEventListener('click', this.handleGlobalClick)
   }
 
-  getFile = (key) => this.props.files.find(f => f.key === key)
+  getFile = (key) => {
+    let hasPrefix = false
+    const exactFolder = this.props.files.find((f) => {
+      if (f.key.startsWith(key)) {
+        hasPrefix = true
+      }
+      return f.key === key
+    })
+    if (exactFolder) {
+      return exactFolder
+    }
+    if (hasPrefix) {
+      return { key, modified: 0, size: 0, relativeKey: key }
+    }
+  }
 
   // item manipulation
   createFiles = (files, prefix) => {


### PR DESCRIPTION
Fixes: https://github.com/uptick/react-keyed-file-browser/issues/115

If your files look like
`/a/b/c.txt, /a/b/d.txt`, then you will get undefined for the folder calls because no folders have been defined.

If you have `/a/, a/b/, /a/b/c.txt, /a/b/d.txt` then you will get the folder you are looking for.

The problem lies in https://github.com/uptick/react-keyed-file-browser/blob/master/src/browser.js#L178
where .find is looking for an exact match in all the files.

I would argue that a user should not have to specify all the folders and if a prefix exists. The onSelect callback should return a folder with 0 for modified and size.