### PR TITLE
fix: adds browser props to onFolder* callbacks

### DIFF
--- a/src/browser.js
+++ b/src/browser.js
@@ -405,7 +405,7 @@ class RawFileBrowser extends React.Component {
       return stateChanges
     }, () => {
       const callback = isOpen ? 'onFolderClose' : 'onFolderOpen'
-      this.props[callback](this.getFile(folderKey))
+      this.props[callback](this.getFile(folderKey), this.getBrowserProps())
     })
   }
 

--- a/src/browser.js
+++ b/src/browser.js
@@ -416,7 +416,7 @@ class RawFileBrowser extends React.Component {
         [folderKey]: true,
       },
     }), () => {
-      this.props.onFolderOpen(this.getFile(folderKey))
+      this.props.onFolderOpen(this.getFile(folderKey), this.getBrowserProps())
     })
   }
 


### PR DESCRIPTION
## Description

* added the second argument to _onFolderOpen_ and _onFolderClose_ (the need was to manipulate the browser's state from these callbacks)

## Changelog

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

## How Has This Been Tested?

- [x] I integrated it with my codebase


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings