### PR TITLE
Exposing component methods (forwardRef)

### DIFF
--- a/src/browser.js
+++ b/src/browser.js
@@ -420,6 +420,12 @@ class RawFileBrowser extends React.Component {
     })
   }
 
+  setOpenFolders = (folderKeys) => {
+    this.setState(prevState => ({
+      openFolders: folderKeys.reduce((folders, folder) => ({ ...folders, [folder]: true }), {}),
+    }))
+  }
+
   // event handlers
   handleGlobalClick = (event) => {
     const inBrowser = !!(this.browserRef && this.browserRef.contains(event.target))

--- a/src/browser.js
+++ b/src/browser.js
@@ -854,15 +854,11 @@ class RawFileBrowser extends React.Component {
   }
 }
 
-class FileBrowser extends Component {
-  render() {
-    return (
-      <DndProvider backend={HTML5Backend}>
-        <RawFileBrowser {...this.props} />
-      </DndProvider>
-    )
-  }
-}
+const FileBrowser = React.forwardRef((props, ref) => (
+  <DndProvider backend={HTML5Backend}>
+    <RawFileBrowser ref={ref} {...props} />
+  </DndProvider>)
+)
 
 export default FileBrowser
 


### PR DESCRIPTION
According to React documentation, this is a breaking change. Unfortunately, this is the only way to use methods like _toggleFolder_ or manipulate a component's state from the outside.