### PR TITLE
feat: noFilesMessage can be a component + added noMatchingFilesMessage

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-keyed-file-browser",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "description": "Folder based file browser given a flat keyed list of objects, powered by React.",
   "main": "index.js",
   "scripts": {

--- a/src/browser.js
+++ b/src/browser.js
@@ -47,7 +47,8 @@ class RawFileBrowser extends React.Component {
     showActionBar: PropTypes.bool.isRequired,
     canFilter: PropTypes.bool.isRequired,
     showFoldersOnFilter: PropTypes.bool,
-    noFilesMessage: PropTypes.string,
+    noFilesMessage: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
+    noMatchingFilesMessage: PropTypes.func,
 
     group: PropTypes.func.isRequired,
     sort: PropTypes.func.isRequired,
@@ -113,6 +114,7 @@ class RawFileBrowser extends React.Component {
     canFilter: true,
     showFoldersOnFilter: false,
     noFilesMessage: 'No files.',
+    noMatchingFilesMessage: (filter) => `No files matching "${filter}".`,
 
     group: GroupByFolder,
     sort: SortByName,
@@ -723,7 +725,7 @@ class RawFileBrowser extends React.Component {
             contents = (
               <tr>
                 <td colSpan={100}>
-                  No files matching "{this.state.nameFilter}".
+                  {this.props.noMatchingFilesMessage(this.state.nameFilter)}
                 </td>
               </tr>
             )
@@ -781,9 +783,9 @@ class RawFileBrowser extends React.Component {
       case 'list':
         if (!contents.length) {
           if (this.state.nameFilter) {
-            contents = (<p className="empty">No files matching "{this.state.nameFilter}"</p>)
+            contents = (<p className="empty">{this.props.noMatchingFilesMessage(this.state.nameFilter)}</p>)
           } else {
-            contents = (<p className="empty">No files.</p>)
+            contents = (<p className="empty">{this.props.noFilesMessage}</p>)
           }
         } else {
           let more


### PR DESCRIPTION
## Description

The message for "no files" scenario can be only a text. I've extended proptypes to allow using a component.
The message for "no files matching the name filter" scenario is hardcoded. I've added a new prop to allow customizing that message.


## Changelog

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Tested manually in our codebase.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings