### PR TITLE
fix: stop rename and delete submit events from propagating

### DIFF
--- a/src/base-folder.js
+++ b/src/base-folder.js
@@ -76,6 +76,7 @@ class BaseFolder extends React.Component {
   }
   handleRenameSubmit = (event) => {
     event.preventDefault()
+    event.stopPropagation()
     if (!this.props.browserProps.renameFolder && !this.props.isDraft) {
       return
     }
@@ -119,6 +120,7 @@ class BaseFolder extends React.Component {
   }
   handleDeleteSubmit = (event) => {
     event.preventDefault()
+    event.stopPropagation()
     if (!this.props.browserProps.deleteFolder) {
       return
     }


### PR DESCRIPTION
If there's a `submit` event listener higher up (i.e. on document), renaming and deleting will allow that listener to fire. This shouldn't happen as the rename and delete processes should be entirely contained (hence why we have `preventDefault` in there.) This fixes that.