### PR TITLE
feat: configurable results limit

### DIFF
--- a/src/browser.js
+++ b/src/browser.js
@@ -48,6 +48,7 @@ class RawFileBrowser extends React.Component {
     canFilter: PropTypes.bool.isRequired,
     showFoldersOnFilter: PropTypes.bool,
     noFilesMessage: PropTypes.string,
+    searchResultsPerPage: PropTypes.number,
 
     group: PropTypes.func.isRequired,
     sort: PropTypes.func.isRequired,
@@ -113,6 +114,7 @@ class RawFileBrowser extends React.Component {
     canFilter: true,
     showFoldersOnFilter: false,
     noFilesMessage: 'No files.',
+    searchResultsPerPage: SEARCH_RESULTS_PER_PAGE,
 
     group: GroupByFolder,
     sort: SortByName,
@@ -156,7 +158,7 @@ class RawFileBrowser extends React.Component {
     actionTargets: [],
 
     nameFilter: '',
-    searchResultsShown: SEARCH_RESULTS_PER_PAGE,
+    searchResultsShown: this.props.searchResultsPerPage,
 
     previewFile: null,
 
@@ -387,7 +389,7 @@ class RawFileBrowser extends React.Component {
   handleShowMoreClick = (event) => {
     event.preventDefault()
     this.setState(prevState => ({
-      searchResultsShown: prevState.searchResultsShown + SEARCH_RESULTS_PER_PAGE,
+      searchResultsShown: prevState.searchResultsShown + this.props.searchResultsPerPage,
     }))
   }
 
@@ -487,7 +489,7 @@ class RawFileBrowser extends React.Component {
   updateFilter = (newValue) => {
     this.setState({
       nameFilter: newValue,
-      searchResultsShown: SEARCH_RESULTS_PER_PAGE,
+      searchResultsShown: this.props.searchResultsPerPage,
     })
   }
 

--- a/src/browser.js
+++ b/src/browser.js
@@ -744,11 +744,12 @@ class RawFileBrowser extends React.Component {
             contents = contents.slice(0, this.state.searchResultsShown)
             if (numFiles > contents.length) {
               contents.push(
-                <tr key="show-more">
+                <tr key="show-more" className="show-more-row">
                   <td colSpan={100}>
                     <a
                       onClick={this.handleShowMoreClick}
                       href="#"
+                      className="show-more"
                     >
                       Show more results
                     </a>
@@ -797,6 +798,7 @@ class RawFileBrowser extends React.Component {
                 <a
                   onClick={this.handleShowMoreClick}
                   href="#"
+                  className="show-more"
                 >
                   Show more results
                 </a>


### PR DESCRIPTION
## Description

Added a new prop for configuring the number of search results per page. Also, I added class names for "show more results" link.

## Changelog

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Tested manually in our codebase.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings