### PR TITLE
correct lodash.flow imports

### DIFF
--- a/src/files/list-thumbnail.js
+++ b/src/files/list-thumbnail.js
@@ -3,7 +3,7 @@ import ClassNames from 'classnames'
 import { DragSource, DropTarget } from 'react-dnd'
 import { NativeTypes } from 'react-dnd-html5-backend'
 import { formatDistanceToNow } from 'date-fns'
-import flow from 'lodash/flow'
+import flow from 'lodash.flow'
 
 import BaseFile, { BaseFileConnectors } from './../base-file.js'
 import { fileSize } from './utils.js'

--- a/src/files/table.js
+++ b/src/files/table.js
@@ -3,7 +3,7 @@ import ClassNames from 'classnames'
 import { DragSource, DropTarget } from 'react-dnd'
 import { NativeTypes } from 'react-dnd-html5-backend'
 import { formatDistanceToNow } from 'date-fns'
-import flow from 'lodash/flow'
+import flow from 'lodash.flow'
 
 import BaseFile, { BaseFileConnectors } from './../base-file.js'
 import { fileSize } from './utils.js'

--- a/src/folders/list-thumbnail.js
+++ b/src/folders/list-thumbnail.js
@@ -2,7 +2,7 @@ import React from 'react'
 import ClassNames from 'classnames'
 import { DragSource, DropTarget } from 'react-dnd'
 import { NativeTypes } from 'react-dnd-html5-backend'
-import flow from 'lodash/flow'
+import flow from 'lodash.flow'
 
 import BaseFolder, { BaseFolderConnectors } from './../base-folder.js'
 import { BaseFileConnectors } from './../base-file.js'

--- a/src/folders/table.js
+++ b/src/folders/table.js
@@ -2,7 +2,7 @@ import React from 'react'
 import ClassNames from 'classnames'
 import { DragSource, DropTarget } from 'react-dnd'
 import { NativeTypes } from 'react-dnd-html5-backend'
-import flow from 'lodash/flow'
+import flow from 'lodash.flow'
 
 import BaseFolder, { BaseFolderConnectors } from './../base-folder.js'
 import { BaseFileConnectors } from './../base-file.js'


### PR DESCRIPTION
Hi,

can you please review patch to correctly import the `lodash.flow` package. It fixes #252.

The package was incorrectly imported using `lodash/flow`, which expected the full `lodash` package to be present for the `/` syntax to work.

The way it got away with it so far is because `lodash` is installed locally as part of storybook in development.

Thanks